### PR TITLE
Add start_type  params support 

### DIFF
--- a/lib/webinar_ru/api/v3/event_sessions.rb
+++ b/lib/webinar_ru/api/v3/event_sessions.rb
@@ -24,6 +24,7 @@ WebinarRu::Api::V3::Client.scope :event_sessions do
     option :name,                 optional: true
     option :access, proc(&:to_i), optional: true
     option :description,          optional: true
+    option :start_type,           optional: true
     option :starts_at,            optional: true
     option :image,                optional: true
     option :lang, proc(&:upcase), optional: true

--- a/lib/webinar_ru/api/v3/events.rb
+++ b/lib/webinar_ru/api/v3/events.rb
@@ -127,6 +127,7 @@ WebinarRu::Api::V3::Client.scope :events do
       option :access, proc(&:to_i)
 
       option :description,          optional: true
+      option :start_type,           optional: true
       option :starts_at,            optional: true
       option :image,                optional: true
       option :lang, proc(&:upcase), optional: true

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -10,6 +10,7 @@ RSpec.shared_context "with params", params: true do
   end
   let(:rule) { "FREQ=DAILY" }
   let(:is_event_reg_allowed) { true }
+  let(:start_type) { "autostart" }
   let(:start_at) do
     {
       "date" => { "year" => 2020, "month" => 12, "day" => 1 },

--- a/spec/webinar_ru/api/v3/event_sessions_spec.rb
+++ b/spec/webinar_ru/api/v3/event_sessions_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe WebinarRu::Api::V3::Client, :test_connection, :params do
           access: access_type,
           description: description,
           additional_fields: additional_fields,
+          start_type: start_type,
           starts_at: Time.utc(2020, 12, 1, 9, 30).to_i,
           lang: :ru,
           image: image_id,
@@ -45,6 +46,7 @@ RSpec.describe WebinarRu::Api::V3::Client, :test_connection, :params do
           request_method: "PUT",
           body: {
             'name' => event_name,
+            'startType' => start_type,
             'access' => access_type.to_s,
             'description' => description,
             'lang' => lang,

--- a/spec/webinar_ru/api/v3/events_spec.rb
+++ b/spec/webinar_ru/api/v3/events_spec.rb
@@ -264,6 +264,7 @@ RSpec.describe WebinarRu::Api::V3::Client do
           name: event_name,
           access: access_type,
           description: description,
+          start_type: start_type,
           starts_at: Time.utc(2020, 12, 1, 9, 30).to_i,
           lang: :ru,
           image: image_id,
@@ -276,6 +277,7 @@ RSpec.describe WebinarRu::Api::V3::Client do
           request_method: "POST",
           body: {
             'name' => event_name,
+            'startType' => start_type,
             'access' => access_type.to_s,
             'description' => description,
             "startsAt[date][day]" => "1",


### PR DESCRIPTION
Add parameter start_type to auto starting webinar.
[Create API DOC](https://help.webinar.ru/ru/articles/3148409-создать-вебинар-eventsession)
[Update APID DOC](https://help.webinar.ru/ru/articles/3149069-отредактировать-вебинар)