### PR TITLE
Proxy without scheme

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    webinar_ru (0.1.5)
+    webinar_ru (0.1.6)
       evil-client
       rate_throttle_client
       tzinfo

--- a/lib/webinar_ru/api/connection.rb
+++ b/lib/webinar_ru/api/connection.rb
@@ -67,7 +67,7 @@ module WebinarRu
         return [] if proxy.nil?
 
         uri = URI(proxy)
-        ["#{uri.scheme}://#{uri.host}", uri.port]
+        [uri.host, uri.port]
       end
 
       def build_from(request)

--- a/lib/webinar_ru/version.rb
+++ b/lib/webinar_ru/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebinarRu
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/webinar_ru/api/connection_spec.rb
+++ b/spec/webinar_ru/api/connection_spec.rb
@@ -26,43 +26,28 @@ RSpec.describe WebinarRu::Api::Connection do
         "rack.logger" => nil
       }
     end
-
-    it "sends request" do
-      stub = stub_request(
+    let!(:stub) do
+      stub_request(
         :get, "https://test.webinar.ru/v3/eventsessions/some-uniq-id"
       ).with(
         headers: {
           "x-auth-token" => "test-token", "Content-Type" => "application/x-www-form-urlencoded"
         }
       ).to_return(body: "abc", status: 200, headers: { "test" => "123" })
+    end
 
+    it "sends request" do
       call_connection
       expect(stub).to have_been_requested
     end
 
     context "with proxy" do
-      before { WebMock.allow_net_connect! }
-      let(:conn) { described_class.new(proxy: proxy) }
+      let(:conn) { described_class.new(proxy: "https://teachbase.com:8888") }
 
-      context "when proxy address with port" do
-        let(:proxy) { "https://teachbase.com:8888" }
-
-        it "connects to proxy first" do
-          expect { call_connection }.to raise_error(SocketError,
-                                                    %r{ open TCP connection to #{proxy} })
-        end
+      it "sends request" do
+        call_connection
+        expect(stub).to have_been_requested
       end
-
-      context "when proxy as host" do
-        let(:proxy) { "https://teachbase.com" }
-
-        it "connects to proxy first" do
-          expect { call_connection }.to raise_error(SocketError,
-                                                    /open TCP connection to #{proxy}:443/)
-        end
-      end
-
-      after { WebMock.disable_net_connect! }
     end
   end
 end


### PR DESCRIPTION
В текущей реализации получаем ошибку:
```ruby
SocketError (Failed to open TCP connection to http://....
```
Убрал схему из proxy. Проверил на стейдже, вебинары создаются.